### PR TITLE
VFD SWMR: Updates the mirror VFD tests so they compile and pass tests…

### DIFF
--- a/doc/vfd-swmr-user-guide.md
+++ b/doc/vfd-swmr-user-guide.md
@@ -103,7 +103,6 @@ be required when building with the Autotools.
 
 Some notes:
 
-- The mirror VFD tests require some rework, so enabling that feature will cause the build step to fail. This will be fixed in a future beta release.
 - The VFD SWMR tests can take some time to run.
 - The VFD SWMR acceptance tests will typically emit some output about "expected errors" that you can ignore. Real errors are clearly flagged.
 - If the tests do not pass on your system, please let the developers know via the email address given at the end of this document.

--- a/test/mirror_vfd.c
+++ b/test/mirror_vfd.c
@@ -59,6 +59,8 @@
 #define DEFAULT_VERBOSITY 1
 static unsigned int g_verbosity = DEFAULT_VERBOSITY;
 
+static struct timespec lastmsgtime = {.tv_sec = 0, .tv_nsec = 0};
+
 /* Macro for selective debug printing / logging */
 #define LOGPRINT(lvl, ...)                                                                                   \
     do {                                                                                                     \
@@ -2169,7 +2171,9 @@ test_on_disk_zoo(void)
      */
 
     if (pass) {
-        create_zoo(file_id, grp_name, 0);
+        pass = create_zoo(
+            file_id, grp_name, &lastmsgtime,
+            (zoo_config_t){.proc_num = 0, .skip_varlen = false, .skip_compact = false, .msgival = {0, 0}});
     }
     if (pass) {
         if (H5Fclose(file_id) == FAIL) {
@@ -2181,7 +2185,9 @@ test_on_disk_zoo(void)
         }
     }
     if (pass) {
-        validate_zoo(file_id, grp_name, 0); /* sanity-check */
+        validate_zoo(
+            file_id, grp_name, &lastmsgtime,
+            (zoo_config_t){.proc_num = 0, .skip_varlen = false, .skip_compact = false, .msgival = {0, 0}});
     }
     if (!pass) {
         HDprintf(failure_mssg);


### PR DESCRIPTION
… (#971)

* Updates the mirror VFD tests so they compile and pass tests

* Committing clang-format changes

Co-authored-by: github-actions <41898282+github-actions[bot]@users.noreply.github.com>